### PR TITLE
Extract `push_raw_url` and `redirect_raw_url`.

### DIFF
--- a/djhtmx/component.py
+++ b/djhtmx/component.py
@@ -74,10 +74,16 @@ class Component:
         self._destroyed = True
 
     def redirect(self, url, **kwargs):
-        self._headers['HX-Redirect'] = resolve_url(url, **kwargs)
+        self.redirect_raw_url(resolve_url(url, **kwargs))
+
+    def redirect_raw_url(self, url):
+        self._headers["HX-Redirect"] = url
 
     def push_url(self, url, **kwargs):
-        self._headers['HX-Push'] = resolve_url(url, **kwargs)
+        self.push_raw_url(resolve_url(url, **kwargs))
+
+    def push_raw_url(self, url):
+        self._headers["HX-Push"] = url
 
     def _send_event(self, target, event):
         self._triggers.after_swap(


### PR DESCRIPTION
We should not assume you'll always use `resolve_url` to resolve URLs.  So
let's provide a more basic method for it.