### PR TITLE
raise useful Error when component is not found

### DIFF
--- a/djhtmx/component.py
+++ b/djhtmx/component.py
@@ -11,8 +11,10 @@ from pydantic import validate_arguments
 from . import json
 from .tracing import sentry_span
 
+
 class ComponentNotFound(LookupError):
     pass
+
 
 class Component:
     template_name = ''
@@ -48,7 +50,9 @@ class Component:
     @classmethod
     def _build(cls, _component_name, request, id, state):
         if not _component_name in cls._all:
-            raise ComponentNotFound(f"Could not find requested component '{_component_name}'. Did you load the component?")
+            raise ComponentNotFound(
+                f"Could not find requested component '{_component_name}'. Did you load the component?"
+            )
         return cls._all[_component_name](**dict(state, id=id, request=request))
 
     def __init__(self, request: HttpRequest, id: str = None):

--- a/djhtmx/component.py
+++ b/djhtmx/component.py
@@ -11,6 +11,8 @@ from pydantic import validate_arguments
 from . import json
 from .tracing import sentry_span
 
+class ComponentNotFound(LookupError):
+    pass
 
 class Component:
     template_name = ''
@@ -45,6 +47,8 @@ class Component:
 
     @classmethod
     def _build(cls, _component_name, request, id, state):
+        if not _component_name in cls._all:
+            raise ComponentNotFound(f"Could not find requested component '{_component_name}'. Did you load the component?")
         return cls._all[_component_name](**dict(state, id=id, request=request))
 
     def __init__(self, request: HttpRequest, id: str = None):


### PR DESCRIPTION
This patch raises a LookupError when a component was requested by {% htmx 'somecomponent' %} that does not exist, due to a typo, not being loaded etc.