### PR TITLE
Add hook 'Component.before_rendering'

### DIFF
--- a/djhtmx/component.py
+++ b/djhtmx/component.py
@@ -112,8 +112,22 @@ class Component:
             response[key] = value
         return response
 
+    def before_render(self) -> None:
+        """Hook called before rendering the template.
+
+        This allows to leave the `__init__` mostly empty, and push some
+        computations after initialization just before rendering.  Which plays
+        nicer with caching.
+
+        This is your last chance to destroy the component if needed.
+
+        """
+        pass
+
     def _render(self, hx_swap_oob=False):
         with sentry_span(f"{self._fqn}._render"):
+            with sentry_span(f"{self._fqn}.before_render"):
+                self.before_render()
             if self._destroyed:
                 html = ''
             else:


### PR DESCRIPTION
Sometimes we want to compute something to decide if the component should be
destroyed or not, however putting this kind of computation directly in
`__init__` doesn't play well with caching (unless you entangle your `__init__`
with caches as well).

This new hook 'before_render' allows to defer the computation until the
render-time.

NB: We're preparing a subclass `CachedHTMXComponent` which leverages allows to
integrate with caches.