### PR TITLE
Fix comparison of non-strings (integers) in query strings.

### DIFF
--- a/src/djhtmx/query.py
+++ b/src/djhtmx/query.py
@@ -138,7 +138,11 @@ class QueryPatcher:
         # Otherwise, let's serialize the value and only update it if it is
         # different.
         serialized_value = self.adapter.dump_python(value, mode="json")
-        if serialized_value == params.get(self.param_name):
+        try:
+            previous_value = self.adapter.validate_python(params.get(self.param_name))
+        except ValueError:
+            previous_value = self.default_value
+        if serialized_value == previous_value:
             return []
         else:
             params[self.param_name] = serialized_value


### PR DESCRIPTION
We were signaling changes in the query string just because 'params.get' would return a string (or None), and not the same type.

Since integers are JSON valid, we were comparing, say, 62 to '62' (a string).

datetimes are unaffected.