### PR TITLE
query.py: Convert querydict param str value to python object

### DIFF
--- a/src/djhtmx/component.py
+++ b/src/djhtmx/component.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 import re
 import time
@@ -8,18 +7,15 @@ import typing as t
 from collections import defaultdict
 from dataclasses import dataclass, field as dataclass_field
 from functools import cache, cached_property, partial
-from itertools import chain
 from os.path import basename
 
 from django.contrib.auth.models import AbstractBaseUser
 from django.db import models
-from django.http import HttpResponse
 from django.shortcuts import resolve_url
 from django.template import Context, loader
 from django.utils.safestring import SafeString, mark_safe
 from pydantic import BaseModel, ConfigDict, Field, validate_call
 from pydantic.fields import ModelPrivateAttr
-from typing_extensions import deprecated
 
 from . import json, settings
 from .introspection import (

--- a/src/djhtmx/consumer.py
+++ b/src/djhtmx/consumer.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, TypeAdapter
 from . import json
 from .component import Command, Destroy, DispatchDOMEvent, Focus, Open, Redirect
 from .introspection import parse_request_data
-from .repo import PushURL, Repository, SendHtml
+from .repo import PushURL, ReplaceURL, Repository, SendHtml
 from .utils import get_params
 
 
@@ -53,7 +53,15 @@ class Consumer(AsyncJsonWebsocketConsumer):
                             "< Command: %s", f"SendHtml[{debug_trace}](... {len(html)} ...)"
                         )
                         await self.send(html)
-                    case Destroy() | Redirect() | Focus() | DispatchDOMEvent() | PushURL() | Open():
+                    case (
+                        Destroy()
+                        | Redirect()
+                        | Focus()
+                        | DispatchDOMEvent()
+                        | PushURL()
+                        | Open()
+                        | ReplaceURL()
+                    ):
                         logger.debug("< Command: %s", command)
                         await self.send_json(command)
                     case _ as unreachable:

--- a/src/djhtmx/introspection.py
+++ b/src/djhtmx/introspection.py
@@ -249,11 +249,14 @@ def is_basic_type(ann):
 
     - Instances of IntEnum or StrEnum.
 
+    - Instances of dict, tuple, list or set
+
     """
     return (
         ann in _SIMPLE_TYPES
         or issubclass_safe(getattr(ann, "__origin__", None), models.Model)
         or issubclass_safe(ann, (enum.IntEnum, enum.StrEnum))
+        or is_collection_annotation(ann)
     )
 
 
@@ -270,5 +273,10 @@ def is_simple_annotation(ann):
     return is_basic_type(ann) or is_union_of_basic(ann)
 
 
+def is_collection_annotation(ann):
+    return issubclass_safe(ann, _COLLECTION_TYPES)
+
+
 Unset = object()
 _SIMPLE_TYPES = (int, str, float, UUID, types.NoneType, date, datetime, bool)
+_COLLECTION_TYPES = (dict, tuple, list, set)

--- a/src/djhtmx/query.py
+++ b/src/djhtmx/query.py
@@ -112,7 +112,7 @@ class QueryPatcher:
                     field_name=field_name,
                     param_name=param_name,
                     signal_name=f"querystring.{param_name}",
-                    auto_subscribe=query.auto_subscribe,
+                    auto_subscribe=query.shared and query.auto_subscribe,
                     default_value=field.get_default(call_default_factory=True),
                     adapter=adapter,
                     use_json=is_collection_annotation(annotation),

--- a/src/djhtmx/query.py
+++ b/src/djhtmx/query.py
@@ -161,7 +161,7 @@ class QueryPatcher:
                 previous_value = self.adapter.dump_json(self.adapter.validate_json(param or ""))
             else:
                 previous_value = self.adapter.dump_python(
-                    self.adapter.validate_python(params.get(self.param_name)),
+                    self.adapter.validate_python(param),
                     mode="json",
                 )
         except ValueError:

--- a/src/djhtmx/repo.py
+++ b/src/djhtmx/repo.py
@@ -73,7 +73,19 @@ class PushURL:
         return cls("?" + params.urlencode())
 
 
-ProcessedCommand = Destroy | Redirect | Open | Focus | DispatchDOMEvent | SendHtml | PushURL
+@dataclass(slots=True)
+class ReplaceURL:
+    url: str
+    command: t.Literal["replace_url"] = "replace_url"
+
+    @classmethod
+    def from_params(cls, params: QueryDict):
+        return cls("?" + params.urlencode())
+
+
+ProcessedCommand = (
+    Destroy | Redirect | Open | Focus | DispatchDOMEvent | SendHtml | PushURL | ReplaceURL
+)
 
 
 class Repository:
@@ -355,7 +367,7 @@ class Repository:
             )
 
         if signals := self.update_params_from(component):
-            yield PushURL.from_params(self.params)
+            yield ReplaceURL.from_params(self.params)
             commands_to_add.append(Signal(signals))
 
         commands.extend(commands_to_add)

--- a/src/djhtmx/templatetags/htmx.py
+++ b/src/djhtmx/templatetags/htmx.py
@@ -12,8 +12,7 @@ from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 
 from .. import json, settings
-from ..component import REGISTRY, HtmxComponent, generate_id
-from ..introspection import get_function_parameters
+from ..component import HtmxComponent
 from ..repo import Repository
 
 register = template.Library()

--- a/src/djhtmx/testing.py
+++ b/src/djhtmx/testing.py
@@ -13,7 +13,7 @@ from pygments.lexers import HtmlLexer
 from . import json
 from .component import Destroy, DispatchDOMEvent, Focus, HtmxComponent, Open, Redirect
 from .introspection import parse_request_data
-from .repo import PushURL, Repository, SendHtml, Session, signer
+from .repo import PushURL, ReplaceURL, Repository, SendHtml, Session, signer
 from .utils import get_params
 
 P = ParamSpec("P")
@@ -181,7 +181,7 @@ class Htmx:
                 case Redirect(url) | Open(url):
                     navigate_to_url = url
 
-                case PushURL(url):
+                case PushURL(url) | ReplaceURL(url):
                     parsed_url = urlparse(url)
                     self.path = parsed_url.path
                     self.query_string = parsed_url.query

--- a/src/djhtmx/urls.py
+++ b/src/djhtmx/urls.py
@@ -12,7 +12,7 @@ from django.utils.html import format_html
 from .component import REGISTRY, Destroy, DispatchDOMEvent, Focus, Open, Redirect, Triggers
 from .consumer import Consumer
 from .introspection import parse_request_data
-from .repo import PushURL, Repository, SendHtml
+from .repo import PushURL, ReplaceURL, Repository, SendHtml
 from .tracing import sentry_span
 
 signer = Signer()
@@ -67,6 +67,8 @@ def endpoint(request: HttpRequest, component_name: str, component_id: str, event
                     content.append(html)
                 case PushURL(url):
                     headers["HX-Push-Url"] = url
+                case ReplaceURL(url):
+                    headers["HX-Replace-Url"] = url
                 case _ as unreachable:
                     assert_never(unreachable)
 

--- a/src/djhtmx/urls.py
+++ b/src/djhtmx/urls.py
@@ -1,6 +1,5 @@
 from functools import partial
 from http import HTTPStatus
-from itertools import chain
 from typing import assert_never
 
 from django.apps import apps
@@ -10,10 +9,9 @@ from django.http.response import HttpResponse
 from django.urls import path, re_path
 from django.utils.html import format_html
 
-from . import json
 from .component import REGISTRY, Destroy, DispatchDOMEvent, Focus, Open, Redirect, Triggers
 from .consumer import Consumer
-from .introspection import filter_parameters, parse_request_data
+from .introspection import parse_request_data
 from .repo import PushURL, Repository, SendHtml
 from .tracing import sentry_span
 


### PR DESCRIPTION
so dict validation doesn't fail