### PR TITLE
Make full async

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,22 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     ...,
-    "djhtmx.Middleware",
+    "djhtmx.middleware",
 ]
 
+TEMPLATES = [
+    {
+        "BACKEND": "...",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                ...,
+                "djhtmx.context.component_repo",
+            ],
+        },
+    },
+]
 ```
 
 Expose the HTTP endpoint in your `urls.py` as you wish, you can use any path you want.
@@ -86,7 +99,7 @@ Counters: <br />
 {% htmx "Counter" counter=3 %}
 ```
 
-##  Doing more complicated stuff
+## Doing more complicated stuff
 
 ### Authentication
 

--- a/src/djhtmx/__init__.py
+++ b/src/djhtmx/__init__.py
@@ -1,16 +1,29 @@
 import typing as t
 
+from asgiref.sync import iscoroutinefunction
 from django.http import HttpRequest, HttpResponse
+from django.utils.decorators import sync_and_async_middleware
 
 
-class Middleware:
-    def __init__(self, get_response: t.Callable[[HttpRequest], HttpResponse]):
-        self.get_response = get_response
+@sync_and_async_middleware
+def middleware(get_response: t.Callable[[HttpRequest], HttpResponse]):
+    # One-time configuration and initialization goes here.
+    if iscoroutinefunction(get_response):
 
-    def __call__(self, request: HttpRequest) -> HttpResponse:
-        """Ensure the Repository gets deallocated"""
-        response = self.get_response(request)
-        if repo := getattr(request, "htmx_repo", None):
-            repo.session.flush()
-            delattr(request, "htmx_repo")
-        return response
+        async def middleware(request: HttpRequest):  # type: ignore
+            response = await get_response(request)
+            if repo := getattr(request, "htmx_repo", None):
+                await repo.session.aflush()
+                delattr(request, "htmx_repo")
+            return response
+
+    else:
+
+        def middleware(request):
+            response = get_response(request)
+            if repo := getattr(request, "htmx_repo", None):
+                repo.session.flush()
+                delattr(request, "htmx_repo")
+            return response
+
+    return middleware

--- a/src/djhtmx/json.py
+++ b/src/djhtmx/json.py
@@ -1,7 +1,7 @@
 import dataclasses
 import enum
 import json
-from typing import Generator
+from collections.abc import Generator
 
 import orjson
 from django.core.serializers import deserialize, serialize
@@ -22,7 +22,7 @@ def encode(instance: models.Model) -> str:
 
 
 def decode(instance: str) -> models.Model:
-    obj: DeserializedObject = list(deserialize("json", instance))[0]
+    obj: DeserializedObject = next(iter(deserialize("json", instance)))
     obj.object.save = obj.save  # type: ignore
     return obj.object
 
@@ -35,14 +35,14 @@ class HtmxEncoder(json.JSONEncoder):
 def default(o):
     try:
         DjangoJSONEncoder().default(o)
-    except TypeError as e:
+    except TypeError:
         if hasattr(o, "__json__"):
             return o.__json__()
 
         if isinstance(o, models.Model):
             return o.pk
 
-        if isinstance(o, (Generator, set, frozenset)):
+        if isinstance(o, Generator | set | frozenset):
             return list(o)
 
         if BaseModel and isinstance(o, BaseModel):
@@ -53,4 +53,4 @@ def default(o):
 
         if isinstance(o, enum.Enum):
             return o.value
-        raise e
+        raise

--- a/src/djhtmx/settings.py
+++ b/src/djhtmx/settings.py
@@ -1,6 +1,8 @@
+import asyncio
+from asyncio.events import AbstractEventLoop
 from datetime import timedelta
+from functools import lru_cache
 
-import redis
 from django.conf import settings
 
 VERSION = "2.0.4"
@@ -14,7 +16,26 @@ SCRIPT_URLS = [
 ]
 
 DEFAULT_LAZY_TEMPLATE = getattr(settings, "DJHTMX_DEFAULT_LAZY_TEMPLATE", "htmx/lazy.html")
-conn = redis.from_url(getattr(settings, "DJHTMX_REDIS_URL", "redis://localhost/0"))
+
+
+def async_connection():
+    return _async_connection(asyncio.get_running_loop())
+
+
+@lru_cache
+def _async_connection(loop: AbstractEventLoop):
+    from redis.asyncio import from_url
+
+    return from_url(getattr(settings, "DJHTMX_REDIS_URL", "redis://localhost/0"))
+
+
+@lru_cache
+def sync_connection():
+    from redis import from_url
+
+    return from_url(getattr(settings, "DJHTMX_REDIS_URL", "redis://localhost/0"))
+
+
 SESSION_TTL = getattr(settings, "DJHTMX_SESSION_TTL", 3600)
 if isinstance(SESSION_TTL, timedelta):
     SESSION_TTL = int(SESSION_TTL.total_seconds())

--- a/src/djhtmx/settings.py
+++ b/src/djhtmx/settings.py
@@ -44,7 +44,7 @@ if isinstance(SESSION_TTL, timedelta):
 STRICT_EVENT_HANDLER_CONSISTENCY_CHECK = getattr(
     settings,
     "DJHTMX_STRICT_EVENT_HANDLER_CONSISTENCY_CHECK",
-    False,
+    True,
 )
 
 KEY_SIZE_ERROR_THRESHOLD = getattr(

--- a/src/djhtmx/urls.py
+++ b/src/djhtmx/urls.py
@@ -18,7 +18,9 @@ from .tracing import sentry_span
 signer = Signer()
 
 
-def endpoint(request: HttpRequest, component_name: str, component_id: str, event_handler: str):
+async def endpoint(
+    request: HttpRequest, component_name: str, component_id: str, event_handler: str
+):
     if "HTTP_HX_SESSION" not in request.META:
         return HttpResponse("Missing header HX-Session", status=HTTPStatus.BAD_REQUEST)
 
@@ -28,7 +30,7 @@ def endpoint(request: HttpRequest, component_name: str, component_id: str, event
         headers: dict[str, str] = {}
         triggers = Triggers()
 
-        for command in repo.dispatch_event(
+        async for command in repo.dispatch_event(
             component_id,
             event_handler,
             parse_request_data(request.POST),

--- a/src/tests/fision/settings.py
+++ b/src/tests/fision/settings.py
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    "djhtmx.Middleware",
+    "djhtmx.middleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -87,7 +87,6 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
-        "ATOMIC_REQUESTS": True,
         "OPTIONS": {
             "timeout": 20,
         },

--- a/src/tests/fision/todo/htmx.py
+++ b/src/tests/fision/todo/htmx.py
@@ -95,8 +95,8 @@ class ListHeader(HtmxComponent):
     def _handle_event(self, event: ItemsCleared | int):
         pass
 
-    def add(self, new_item: str):
-        item = Item.objects.create(text=new_item)
+    async def add(self, new_item: str):
+        item = await Item.objects.acreate(text=new_item)
         yield BuildAndRender.append("#todo-list", TodoItem, id=f"item-{item.id}", item=item)
 
 


### PR DESCRIPTION
:warning:  This requires disabling `ATOMIC_REQUESTS`! 

This allows for event handlers to be async.  This is the way forward to WebSockets.

We you can have:

```python
class Component(HtmxComponent):
    async def do_something(self):
        instance = await Model.objects.acreate(...)
        yield Redirect.to(instance)
```

It also can handle the sync way:

```python
class Component(HtmxComponent):
    def do_something(self):
        instance = Model.objects.create(...)
        yield Redirect.to(instance)
```

And you can have mixed types of event handlers in the same component.
When a sync handler is found it is run inside a transaction using `atomic()`
