### PR TITLE
fix(query): Preserve metadata on inherited Model `Query` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Command classes (`Destroy`, `Redirect`, `Open`, `Focus`, `ScrollIntoView`, `DispatchDOMEvent`, `Render`, `BuildAndRender`, `Emit`, `Execute`, `SkipRender`, `PushURL`, `ReplaceURL`, `SendHtml`, and the `Command` union) now live in `djhtmx.commands`.  Update imports to `from djhtmx.commands import …`.  The `Command` union is also narrower: `Signal` and `SendHtml` are framework internals and no longer in it.
 
+### Fixed
+
+- **Inherited `Query` fields of Django Model type**: `QueryPatcher.for_component` now reconstructs the full annotation from `field.annotation` + `field.metadata` instead of reading `component.__annotations__[field_name]`.  The previous lookup only inspected the class's own annotations (no MRO walk) and silently fell through to the bare annotation for inherited fields, dropping the `PlainSerializer` that `annotate_model` attaches for Model and QuerySet types.  Components that inherited a field like `Annotated[MyModel | None, Query(...), Field(default=None)]` from an abstract base would raise `PydanticSerializationError: Unable to serialize unknown type` the moment the URL had to be updated.
+
 ## [1.3.12] - 2026-04-24
 
 ### Added

--- a/src/djhtmx/query.py
+++ b/src/djhtmx/query.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any
 
 from django.http import QueryDict
 from pydantic import BaseModel, TypeAdapter
@@ -108,8 +108,20 @@ class QueryPatcher:
                 if not query.shared:
                     param_name = f"{param_name}-{compact_hash(component.__name__)}"
 
-                # Use the full annotation from __annotations__ to preserve serializers
-                full_annotation = component.__annotations__.get(field_name, field.annotation)
+                # Use the full annotation (with the validator/serializer that `annotate_model`
+                # attaches for Model and QuerySet types) so the adapter knows how to convert between
+                # the model instance and its PK in the URL.
+                #
+                # We reconstruct it from `field.annotation` + `field.metadata` rather than reading
+                # `component.__annotations__[field_name]`, because `cls.__annotations__` is the
+                # class's own dict and is *not* walked along the MRO.  A field declared on an
+                # abstract base and inherited by a concrete component would otherwise fall through
+                # to the bare `field.annotation` and drop the PlainSerializer — `dump_python` then
+                # fails to serialise the model instance.
+                if field.metadata:
+                    full_annotation = Annotated[field.annotation, *field.metadata]
+                else:
+                    full_annotation = field.annotation
                 adapter = get_annotation_adapter(full_annotation)
                 yield cls(
                     field_name=field_name,

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -1,0 +1,58 @@
+"""Tests for `djhtmx.query.QueryPatcher`."""
+
+from typing import Annotated
+
+from django.http import QueryDict
+from django.test import TestCase
+from fision.todo.models import Item  # type: ignore[import-untyped]
+from pydantic import Field
+
+from djhtmx.component import HtmxComponent, Query
+from djhtmx.query import QueryPatcher
+
+
+class TestQueryPatcherInheritedModelField(TestCase):
+    """Regression: a Model-typed `Query` field declared on an abstract base
+    must still serialize properly when used through a concrete subclass.
+
+    `cls.__annotations__` is the class's *own* dict and is not walked along the
+    MRO, so the patcher needs to reconstruct the full annotation from the
+    pydantic ``FieldInfo`` (``annotation`` + ``metadata``).  Otherwise the
+    fallback drops the ``PlainSerializer`` added by ``annotate_model`` and
+    ``dump_python`` blows up on the model instance.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.item = Item.objects.create(text="hello")
+
+    def test_patcher_serializes_model_pk_for_inherited_field(self):
+        class _AbstractBase(HtmxComponent, public=False):
+            editing: Annotated[Item | None, Query("editing"), Field(default=None)]
+
+        class _Concrete(_AbstractBase):
+            _template_name = "_Concrete.html"
+
+        [patcher] = list(QueryPatcher.for_component(_Concrete))
+        self.assertEqual(patcher.field_name, "editing")
+
+        # Round-trip: serializing a model instance must write its PK to the URL.
+        params = QueryDict("", mutable=True)
+        patcher.get_updates_for_params(self.item, params)
+        self.assertEqual(params[patcher.param_name], str(self.item.pk))
+
+        # Round-trip the other way: a PK in the URL must resurrect the instance.
+        update = patcher.get_update_for_state(params)
+        self.assertEqual(update[patcher.field_name], self.item)
+
+    def test_patcher_serializes_model_pk_for_own_field(self):
+        # Sanity check: the same scenario works when the field is declared
+        # directly on the public component (no inheritance involved).
+        class _Concrete(HtmxComponent, public=False):
+            _template_name = "_Concrete.html"
+            editing: Annotated[Item | None, Query("editing"), Field(default=None)]
+
+        [patcher] = list(QueryPatcher.for_component(_Concrete))
+        params = QueryDict("", mutable=True)
+        patcher.get_updates_for_params(self.item, params)
+        self.assertEqual(params[patcher.param_name], str(self.item.pk))


### PR DESCRIPTION
`QueryPatcher.for_component` used to look up the rewritten annotation in `component.__annotations__[field_name]` and fall back to `field.annotation` otherwise.  Both `cls.__annotations__` and that fallback drop the `PlainSerializer` / `PlainValidator` that `annotate_model` attaches for Django Model and QuerySet types — `__annotations__` because it is the class's *own* dict (no MRO walk), and `field.annotation` because pydantic stores the bare type with metadata kept separately.

The result was that a public component which inherited a Query field like

    editing: Annotated[Item | None, Query("editing"), Field(default=None)]

from an abstract base would build an adapter that knew how to validate but not how to serialise: as soon as the URL needed to be updated for the chosen instance, `dump_python` raised
`PydanticSerializationError: Unable to serialize unknown type`.

Reconstruct the annotation from `field.annotation` + `field.metadata` instead.  Pydantic carries the metadata along through inheritance, so the adapter now picks up the model-PK serializer regardless of where the field was declared in the MRO.

Add `test_query.py` covering both inherited and own-field declaration so the regression cannot return.