### PR TITLE
fix(sse): Skip envelopes whose payload type can no longer be imported

### DIFF
--- a/src/djhtmx/sse.py
+++ b/src/djhtmx/sse.py
@@ -295,9 +295,19 @@ class EventEnvelope[P: BaseModel](BaseModel):
         return self.model_dump_json()
 
     @classmethod
-    def envelope_validate_json(cls, data):
+    def envelope_validate_json(cls, data) -> EventEnvelope | None:
         extracted = cls.model_validate_json(data)
-        payload_type: BaseModel = import_object(extracted.payload_fqn)
+        try:
+            payload_type: BaseModel = import_object(extracted.payload_fqn)
+        except (ImportError, AttributeError):
+            # The payload class was removed or renamed since this envelope was
+            # enqueued (e.g. a consumer still watching an event type dropped in a
+            # deploy).  Skip it instead of crashing the whole SSE stream.
+            logger.warning(
+                "Dropping SSE envelope with unimportable payload type %r",
+                extracted.payload_fqn,
+            )
+            return None
         extracted.payload = payload_type.model_validate(extracted.payload_data)  # type: ignore
         return extracted
 
@@ -444,8 +454,8 @@ async def render_sse_event_fragments(
 
     envelopes_by_consumer: dict[str, list[EventEnvelope]] = defaultdict(list)
     for raw_event in raw_events:
-        envelope = EventEnvelope.envelope_validate_json(raw_event)
-        envelopes_by_consumer[envelope.consumer_id].append(envelope)
+        if envelope := EventEnvelope.envelope_validate_json(raw_event):
+            envelopes_by_consumer[envelope.consumer_id].append(envelope)
 
     handle_commands: list[HandleSSEEvents] = []
     for consumer_id, envelopes in envelopes_by_consumer.items():

--- a/src/djhtmx/sse.py
+++ b/src/djhtmx/sse.py
@@ -20,7 +20,7 @@ from typing import (
 
 import redis
 import redis.asyncio as async_redis
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 from redis.exceptions import WatchError
 from xotl.tools.objects import import_object
 
@@ -299,16 +299,17 @@ class EventEnvelope[P: BaseModel](BaseModel):
         extracted = cls.model_validate_json(data)
         try:
             payload_type: BaseModel = import_object(extracted.payload_fqn)
-        except (ImportError, AttributeError):
-            # The payload class was removed or renamed since this envelope was
-            # enqueued (e.g. a consumer still watching an event type dropped in a
-            # deploy).  Skip it instead of crashing the whole SSE stream.
+            extracted.payload = payload_type.model_validate(extracted.payload_data)  # type: ignore
+        except (ImportError, AttributeError, ValidationError):
+            # The payload class was removed or renamed, or its schema changed
+            # incompatibly, since this envelope was enqueued (e.g. a consumer
+            # still watching an event type altered in a deploy).  Skip it instead
+            # of crashing the whole SSE stream.
             logger.warning(
-                "Dropping SSE envelope with unimportable payload type %r",
+                "Dropping SSE envelope with stale payload type %r",
                 extracted.payload_fqn,
             )
             return None
-        extracted.payload = payload_type.model_validate(extracted.payload_data)  # type: ignore
         return extracted
 
 


### PR DESCRIPTION
When a consumer is still watching an event type that was removed or renamed in a deploy, its persisted envelope in Redis names a payload class that no longer exists.  Reconstructing it via `import_object` then raised `AttributeError` (or `ImportError`), and because this happened while draining the whole session events list, a single stale envelope crashed the entire SSE stream for the connection.

`envelope_validate_json` now catches the import failure, logs a warning, and returns None so the offending envelope is dropped individually while the rest of the batch is delivered normally.
