### PR TITLE
fix(query): Catch Django ValidationError for malformed query values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Malformed query values for Model-typed `Query` fields**: `QueryPatcher` now also catches Django's `ValidationError` (not only `ValueError`) when validating a value from the query string, falling back to the field default instead of failing the request.  Resolving a Model `Query` field from its PK runs `Model.objects.filter(pk=value)`, and a value the PK field cannot parse (e.g. a non-UUID string for a `UUIDField`) raises `django.core.exceptions.ValidationError`, which is *not* a subclass of `ValueError`.  A stray `?param=garbage` in the URL therefore raised during component build and returned an HTTP 500.  Both `get_update_for_state` and `get_updates_for_params` are fixed.
+
 - **Inherited `Query` fields of Django Model type**: `QueryPatcher.for_component` now reconstructs the full annotation from `field.annotation` + `field.metadata` instead of reading `component.__annotations__[field_name]`.  The previous lookup only inspected the class's own annotations (no MRO walk) and silently fell through to the bare annotation for inherited fields, dropping the `PlainSerializer` that `annotate_model` attaches for Model and QuerySet types.  Components that inherited a field like `Annotated[MyModel | None, Query(...), Field(default=None)]` from an abstract base would raise `PydanticSerializationError: Unable to serialize unknown type` the moment the URL had to be updated.
 
 ## [1.3.12] - 2026-04-24

--- a/src/djhtmx/query.py
+++ b/src/djhtmx/query.py
@@ -4,6 +4,7 @@ import re
 from dataclasses import dataclass
 from typing import Annotated, Any
 
+from django.core.exceptions import ValidationError
 from django.http import QueryDict
 from pydantic import BaseModel, TypeAdapter
 from pydantic.fields import FieldInfo
@@ -136,16 +137,18 @@ class QueryPatcher:
     def get_update_for_state(self, params: QueryDict):
         if (raw_param := params.get(self.param_name)) is not None:
             # We need to perform the validation during patching, otherwise
-            # ill-formed values in the query will cause a Pydantic
-            # ValidationError, but we should just simply ignore invalid
-            # values.
+            # ill-formed values in the query will raise, but we should just
+            # simply ignore invalid values.  Pydantic raises a ValueError
+            # subclass; model-resolving adapters (a PK in the URL that fails to
+            # parse or match a row) raise Django's ValidationError, which is
+            # *not* a ValueError -- catch both.
             try:
                 return {
                     self.field_name: self.adapter.validate_json(raw_param)
                     if self.use_json
                     else self.adapter.validate_python(raw_param)
                 }
-            except ValueError:
+            except (ValueError, ValidationError):
                 # Preserve the last good known state in the component
                 return {}
         else:
@@ -179,7 +182,10 @@ class QueryPatcher:
                     self.adapter.validate_python(param),
                     mode="json",
                 )
-        except ValueError:
+        except (ValueError, ValidationError):
+            # A malformed value already sitting in the URL can't be parsed back;
+            # treat it as the default so the fresh value overwrites it.  Django's
+            # ValidationError (from model-resolving adapters) is not a ValueError.
             previous_value = self.default_value
 
         if serialized_value == previous_value:

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -56,3 +56,40 @@ class TestQueryPatcherInheritedModelField(TestCase):
         params = QueryDict("", mutable=True)
         patcher.get_updates_for_params(self.item, params)
         self.assertEqual(params[patcher.param_name], str(self.item.pk))
+
+
+class TestQueryPatcherInvalidValue(TestCase):
+    """Regression: a malformed value in the URL for a model-typed `Query` field
+    must fall back to the default instead of raising.
+
+    Resolving a model from its PK runs the field's adapter, and a value the PK
+    field can't parse (here a non-numeric id) raises Django's `ValidationError`,
+    which is *not* a `ValueError`.  Both query entry points have to swallow it.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.item = Item.objects.create(text="hello")
+
+    def _patcher(self):
+        class _Concrete(HtmxComponent, public=False):
+            _template_name = "_Concrete.html"
+            editing: Annotated[Item | None, Query("editing"), Field(default=None)]
+
+        [patcher] = list(QueryPatcher.for_component(_Concrete))
+        return patcher
+
+    def test_get_update_for_state_falls_back_on_malformed_value(self):
+        patcher = self._patcher()
+        params = QueryDict(f"{patcher.param_name}=not-an-id", mutable=True)
+        # Must not raise; the malformed value is ignored so the default applies.
+        self.assertEqual(patcher.get_update_for_state(params), {})
+
+    def test_get_updates_for_params_falls_back_on_malformed_existing_value(self):
+        patcher = self._patcher()
+        # The URL already holds a malformed value; writing a fresh value must
+        # not choke on parsing the stale one back for comparison.
+        params = QueryDict(f"{patcher.param_name}=not-an-id", mutable=True)
+        signals = patcher.get_updates_for_params(self.item, params)
+        self.assertEqual(params[patcher.param_name], str(self.item.pk))
+        self.assertEqual(signals, [patcher.signal_name])


### PR DESCRIPTION
Resolving a Model-typed `Query` field from its PK runs `Model.objects.filter(pk=value)`.  A value the PK field cannot parse (e.g. a non-UUID string for a `UUIDField`) raises Django's `ValidationError`, which is not a subclass of `ValueError`, so `QueryPatcher`'s `except ValueError` let it escape: a stray `?param=garbage` in the URL raised during component build and returned an HTTP 500.

Broaden both validation sites (`get_update_for_state` and `get_updates_for_params`) to also catch `ValidationError` and fall back to the field default.  Add regression tests covering both methods.